### PR TITLE
Prevent errors when urls can't be converted.

### DIFF
--- a/TextformatterOEmbed.module
+++ b/TextformatterOEmbed.module
@@ -122,6 +122,9 @@ class TextformatterOEmbed extends Textformatter implements ConfigurableModule {
 		if($result->num_rows) {
 			list($embedCode, $itemService, $itemType) = $result->fetch_row(); 
 		} else {
+			if ($embed === NULL){
+			     return;
+			}
 
 			$embed = $this->essence->extract( $url , [
 			    'maxwidth' => $this->maxWidth,

--- a/TextformatterOEmbed.module
+++ b/TextformatterOEmbed.module
@@ -122,14 +122,14 @@ class TextformatterOEmbed extends Textformatter implements ConfigurableModule {
 		if($result->num_rows) {
 			list($embedCode, $itemService, $itemType) = $result->fetch_row(); 
 		} else {
-			if ($embed === NULL){
-			     return;
-			}
-
 			$embed = $this->essence->extract( $url , [
 			    'maxwidth' => $this->maxWidth,
 			    'maxheight' => $this->maxHeight
 			]);
+
+			if ($embed === NULL){
+			     return;
+			}
 
 			$embedCode = $embed->html;
 


### PR DESCRIPTION
I noticed some embedded urls causes php errors if the essence library can't convert them for some reason.

Here is the error:
PHP Notice: Trying to get property of non-object in .../TextformatterOEmbed/TextformatterOEmbed.module:131

Example https://soundcloud.com/thirdday/i-need-a-miracle-1

This code adds a check to make sure there is data before it is accessed.  If there are an errors with the embedded url, it will leave it as is and skip over it.

We should probably also include a session message to the user to let them know there was a problem.  Maybe something like this before the return statement:

`wire('session')->message("Could not convert embedded oembed link - {$url}.");`

That works but we also need to sanitize the url.  I wasn't sure on how to do that?

